### PR TITLE
Use classpath-based mock GCP credentials for tests

### DIFF
--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -5,7 +5,7 @@ spring:
         enabled: false
         project-id: test-project-id
         credentials:
-          location: file:C:/Users/chris/.gcp/service-account-key-v2.json
+          location: classpath:dummy-gcp-credentials.json
         topic: credit-transactions
   server:
     port: 8080

--- a/src/test/resources/dummy-gcp-credentials.json
+++ b/src/test/resources/dummy-gcp-credentials.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "test-project-id",
+  "private_key_id": "dummy",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nMII...\n-----END PRIVATE KEY-----\n",
+  "client_email": "dummy@test-project-id.iam.gserviceaccount.com",
+  "client_id": "1234567890",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/dummy%40test-project-id.iam.gserviceaccount.com"
+}


### PR DESCRIPTION
## Summary
- replace hard-coded local credentials path with classpath reference
- add dummy Pub/Sub service account JSON to test resources

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_689bee9860588322964ed0d87ff0193d