### PR TITLE
Mock PubSubTemplate for tests to load Spring context

### DIFF
--- a/src/test/java/com/kenni/datos/datos/DatosApplicationTests.java
+++ b/src/test/java/com/kenni/datos/datos/DatosApplicationTests.java
@@ -3,10 +3,15 @@ package com.kenni.datos.datos;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import com.google.cloud.spring.pubsub.core.PubSubTemplate;
 
 @SpringBootTest
 @ActiveProfiles("test")
 class DatosApplicationTests {
+
+        @MockBean
+        private PubSubTemplate pubSubTemplate;
 
 	@Test
 	void contextLoads() {


### PR DESCRIPTION
## Summary
- mock PubSubTemplate bean in DatosApplicationTests so the Spring context can initialize during tests

## Testing
- `gradle test` *(fails: Plugin [id: 'org.springframework.boot', version: '3.5.4'] was not found in any of the following sources)*

------
https://chatgpt.com/codex/tasks/task_e_689cbcc3c4748322a5654a9a7fd300e9